### PR TITLE
@SWG annotation isn't necessary anymore

### DIFF
--- a/lib/LeroyMerlin/ruleset.xml
+++ b/lib/LeroyMerlin/ruleset.xml
@@ -187,7 +187,6 @@
                 <element value="@group"/>
                 <element value="@link"/>
                 <element value="@see"/>
-                <element value="@SWG\"/>
             </property>
         </properties>
         <!-- Review params before enable it, may be some false-positives -->


### PR DESCRIPTION
With @ravanscafi's work on moving our API documentation from annotation to YAML, this annotation isn't necessary anymore