### PR TITLE
Add Sniff to require the usage of ::class whenever possible

### DIFF
--- a/lib/LeroyMerlin/ruleset.xml
+++ b/lib/LeroyMerlin/ruleset.xml
@@ -87,6 +87,8 @@
     </rule>
     <!-- Require a comma after the last element in multi-line array -->
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
+    <!-- Require usage of ::class whenever possible -->
+    <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
     <!-- Force phpDocs separation between diferrent annotations and remove extra `*` -->
     <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing">
         <properties>

--- a/tests/expected/class-references.php
+++ b/tests/expected/class-references.php
@@ -1,0 +1,21 @@
+<?php
+
+class Foo
+{
+}
+
+class Bar extends Foo
+{
+    /**
+     * @return string[]
+     */
+    public function names(): iterable
+    {
+        yield self::class;
+        yield self::class;
+        yield static::class;
+        yield get_class(new stdClass());
+        yield parent::class;
+        yield static::class;
+    }
+}

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -6,6 +6,7 @@ FILE                                                  ERRORS  WARNINGS
 tests/input/array_indentation.php                     10      0
 tests/input/array_trailing_comma.php                  1       0
 tests/input/assignment-operators.php                  5       0
+tests/input/class-references.php                      11      0
 tests/input/concatenation_spacing.php                 13      0
 tests/input/example-class.php                         28      0
 tests/input/forbidden-comments.php                    5       0
@@ -19,9 +20,9 @@ tests/input/semicolon_spacing.php                     4       0
 tests/input/test-case.php                             1       0
 tests/input/useless-semicolon.php                     4       0
 ----------------------------------------------------------------------
-A TOTAL OF 112 ERRORS AND 0 WARNINGS WERE FOUND IN 15 FILES
+A TOTAL OF 123 ERRORS AND 0 WARNINGS WERE FOUND IN 16 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 105 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 111 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/input/class-references.php
+++ b/tests/input/class-references.php
@@ -1,0 +1,21 @@
+<?php
+
+class Foo
+{
+}
+
+class Bar extends Foo
+{
+    /**
+     * @return string[]
+     */
+    public function names() : iterable
+    {
+        yield __CLASS__;
+        yield get_class();
+        yield get_class($this);
+        yield get_class(new stdClass());
+        yield get_parent_class();
+        yield get_called_class();
+    }
+}


### PR DESCRIPTION
Resolves #9.

This Sniff will enforce the following changes:

* `__CLASS__` to `self::class`
* `get_parent_class()` to parent::class
* `get_called_class()` to static::class
* `get_class()` to self::class
* `get_class($this)` to static::class

This Sniff also improves the performance: https://belineperspectives.com/2017/03/13/get_classthis-vs-staticclass/ :tada: