### PR TITLE
feat: disables enableNativeTypeHint property on slevomat conventions

### DIFF
--- a/lib/LeroyMerlin/custom-slevomat-coding-standard.xml
+++ b/lib/LeroyMerlin/custom-slevomat-coding-standard.xml
@@ -233,7 +233,12 @@
   <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
 
   <!-- Checks property type hint -->
-  <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
+  <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
+    <properties>
+      <!-- Setting `enableNativeTypeHint` to false means that PHPCS will not try to transform @var notations(e.g `@var int $property`) into native typehints on properties(e.g. `int $property`). -->
+      <property name="enableNativeTypeHint" value="false"/>
+    </properties>
+  </rule>
 
   <!-- Checks return type hint -->
   <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">


### PR DESCRIPTION
This PR sets a sniffer to prevent properties declared with _@var notations_ to be transformed on properies with _native type hint_. 
There are a lot of projects using this coding-standard who overrides classes and properties from external libs. 
For this reason, a lot of properties that are overriden can't have a native typehint, because doing so would break those applications. 

For example: 
In the old sniffer, the code above would be rejected: 

```
/**
* @var int $property
*/
private $property;
```
Because the old sniffer would like the code to be written in the following way:
```
private int $property;
```

Now the current sniffer will not be bothered by the first code; also he still will be capable of checking another errors on property type hints, like useless annotations and so on. 